### PR TITLE
[MER-1261] Do not decode response body when posting score

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,3 +3,5 @@ use Mix.Config
 config :lti_1p3,
   http_client: Lti_1p3.Test.MockHTTPoison,
   provider: Lti_1p3.DataProviders.MemoryProvider
+
+config :logger, backends: []

--- a/lib/lti_1p3/tool/services/ags.ex
+++ b/lib/lti_1p3/tool/services/ags.ex
@@ -27,11 +27,9 @@ defmodule Lti_1p3.Tool.Services.AGS do
     url = "#{line_item.id}/scores"
     body = score |> Jason.encode!()
 
-    with {:ok, %HTTPoison.Response{status_code: code, body: body}} when code in [200, 201] <-
-           http_client!().post(url, body, headers(access_token)),
-         {:ok, result} <- Jason.decode(body) do
-      {:ok, result}
-    else
+    case http_client!().post(url, body, headers(access_token)) do
+      {:ok, %HTTPoison.Response{status_code: code, body: body}} when code in [200, 201] ->
+        {:ok, body}
       e ->
         Logger.error(
           "Error encountered posting score for user #{score.userId} for line item '#{line_item.label}' #{inspect(e)}"


### PR DESCRIPTION
[MER-1261](https://eliterate.atlassian.net/browse/MER-1261)

One of our LMS integrations returns an empty body on successful publishing of scores, so the library fails on the `Jason.decode(body)` line with `{:error, %Jason.DecodeError{data: "", position: 0, token: nil}` and from there treats it as an error. 

In addition to syncing with the LMS (and perhaps requesting a change from their side), it made sense to be less restrictive here and let the app consuming the library decide whether to decode the body or do something else with it.