### PR TITLE
[MER-1302] Use registration url when present for line items service url

### DIFF
--- a/lib/lti_1p3/tool/services/ags.ex
+++ b/lib/lti_1p3/tool/services/ags.ex
@@ -214,10 +214,25 @@ defmodule Lti_1p3.Tool.Services.AGS do
   end
 
   @doc """
-  Returns the line items URL from LTI launch params. If not present returns nil.
+  Returns the line items URL from LTI launch params.
+  If not present returns nil.
+  If a registration is present, uses the auth server domain + the line items path.
   """
-  def get_line_items_url(lti_launch_params) do
-    Map.get(lti_launch_params, @lti_ags_claim_url, %{}) |> Map.get("lineitems")
+  def get_line_items_url(lti_launch_params, registration \\ %{}) do
+    line_items_url =
+      lti_launch_params
+      |> Map.get(@lti_ags_claim_url, %{})
+      |> Map.get("lineitems")
+
+    unless is_nil(line_items_url) do
+      %URI{path: line_items_path} = URI.parse(line_items_url)
+
+      registration
+      |> Map.get(:auth_server, line_items_url)
+      |> URI.parse()
+      |> Map.put(:path, line_items_path)
+      |> URI.to_string()
+    end
   end
 
   @doc """

--- a/test/lti_1p3/tool/services/ags_test.exs
+++ b/test/lti_1p3/tool/services/ags_test.exs
@@ -87,9 +87,6 @@ defmodule Lti_1p3.Tool.Services.AGSTest do
   test "ags" do
     assert AGS.grade_passback_enabled?(@lti_params)
 
-    assert AGS.get_line_items_url(@lti_params) ==
-             "https://lms.example.edu/api/lti/courses/8/line_items"
-
     lti_ags_claim = Map.get(@lti_params, "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint")
 
     assert AGS.has_scope?(
@@ -101,5 +98,23 @@ defmodule Lti_1p3.Tool.Services.AGSTest do
              lti_ags_claim,
              "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.fake"
            )
+  end
+
+  describe "get_line_items_url" do
+    test "returns nil if no line items claim in the params" do
+      refute AGS.get_line_items_url(%{})
+      refute AGS.get_line_items_url(%{}, %{})
+    end
+
+    test "returns the url from line items claim when no registration present" do
+      assert AGS.get_line_items_url(@lti_params) ==
+        "https://lms.example.edu/api/lti/courses/8/line_items"
+    end
+
+    test "returns the url from line items claim with the registration auth server domain" do
+      assert AGS.get_line_items_url(@lti_params, %{
+        auth_server: "https://registration.example.com/lti/something"
+      }) == "https://registration.example.com/api/lti/courses/8/line_items"
+    end
   end
 end


### PR DESCRIPTION
We are integrating with Canvas, and users are coming from different URLs (main domain and vanities). After some research, discovered that Canvas is comparing the `aud` claim we set up when getting the access token (which comes from the auth server or token URL configured in the registration) against the URL of the canvas line item service (that gets updated on each launch), so if users are coming from different domains they will potentially differ.

This change aims to set the domain of the registration + the line items path when calculating the line items service url.