### PR TITLE
Use line items domain from registration to build url

### DIFF
--- a/lib/lti_1p3/tool/services/ags.ex
+++ b/lib/lti_1p3/tool/services/ags.ex
@@ -233,14 +233,10 @@ defmodule Lti_1p3.Tool.Services.AGS do
     end
   end
 
-  defp get_line_items_domain(registration, default) do
-    line_items_service_domain = Map.get(registration, :line_items_service_domain)
-
-    cond do
-      is_nil(line_items_service_domain) or line_items_service_domain == "" -> default
-      true -> line_items_service_domain
-    end
-  end
+  defp get_line_items_domain(%{line_items_service_domain: domain}, default)
+    when is_nil(domain) or domain == "", do: default
+  defp get_line_items_domain(%{line_items_service_domain: domain}, _default), do: domain
+  defp get_line_items_domain(_registration, default), do: default
 
   @doc """
   Returns true if the LTI AGS claim has a particular scope url, false if it does not.

--- a/lib/lti_1p3/tool/services/ags.ex
+++ b/lib/lti_1p3/tool/services/ags.ex
@@ -226,10 +226,19 @@ defmodule Lti_1p3.Tool.Services.AGS do
       %URI{path: line_items_path} = URI.parse(line_items_url)
 
       registration
-      |> Map.get(:auth_server, line_items_url)
+      |> get_line_items_domain(line_items_url)
       |> URI.parse()
       |> Map.put(:path, line_items_path)
       |> URI.to_string()
+    end
+  end
+
+  defp get_line_items_domain(registration, default) do
+    line_items_service_domain = Map.get(registration, :line_items_service_domain)
+
+    cond do
+      is_nil(line_items_service_domain) or line_items_service_domain == "" -> default
+      true -> line_items_service_domain
     end
   end
 

--- a/test/lti_1p3/tool/services/ags_test.exs
+++ b/test/lti_1p3/tool/services/ags_test.exs
@@ -111,6 +111,7 @@ defmodule Lti_1p3.Tool.Services.AGSTest do
   describe "get_line_items_url" do
     test "returns nil if no line items claim in the params" do
       refute AGS.get_line_items_url(%{})
+
       refute AGS.get_line_items_url(%{}, %{
         line_items_service_domain: @lti_items_service_domain
       })
@@ -122,8 +123,9 @@ defmodule Lti_1p3.Tool.Services.AGSTest do
     end
 
     test "returns the url from line items claim when registration present but not line_items_service_domain" do
-      assert AGS.get_line_items_url(@lti_params, %{auth_server: "some auth_server"}) ==
-        @line_items_url
+      assert AGS.get_line_items_url(@lti_params, %{
+        auth_server: "some auth_server"
+      }) == @line_items_url
 
       assert AGS.get_line_items_url(@lti_params, %{
         line_items_service_domain: ""
@@ -134,7 +136,7 @@ defmodule Lti_1p3.Tool.Services.AGSTest do
       }) == @line_items_url
     end
 
-    test "returns the url from line items claim with the registration auth server domain" do
+    test "returns the url from line items claim with the registration line_items_service_domain" do
       assert AGS.get_line_items_url(@lti_params, %{
         line_items_service_domain: @lti_items_service_domain
       }) == "https://registration.example.com/api/lti/courses/8/line_items"

--- a/test/lti_1p3/tool/services/ags_test.exs
+++ b/test/lti_1p3/tool/services/ags_test.exs
@@ -8,6 +8,9 @@ defmodule Lti_1p3.Tool.Services.AGSTest do
   alias Lti_1p3.Tool.Services.AGS
   alias Lti_1p3.Tool.Services.AGS.{LineItem, Score}
 
+  @line_items_url "https://lms.example.edu/api/lti/courses/8/line_items"
+  @lti_items_service_domain "https://registration.example.com/lti/something"
+
   @lti_params %{
     "aud" => "10000000000041",
     "azp" => "10000000000041",
@@ -18,7 +21,7 @@ defmodule Lti_1p3.Tool.Services.AGSTest do
     "given_name" => "First",
     "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint" => %{
       "errors" => %{"errors" => %{}},
-      "lineitems" => "https://lms.example.edu/api/lti/courses/8/line_items",
+      "lineitems" => @line_items_url,
       "scope" => [
         "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
         "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
@@ -108,17 +111,32 @@ defmodule Lti_1p3.Tool.Services.AGSTest do
   describe "get_line_items_url" do
     test "returns nil if no line items claim in the params" do
       refute AGS.get_line_items_url(%{})
-      refute AGS.get_line_items_url(%{}, %{})
+      refute AGS.get_line_items_url(%{}, %{
+        line_items_service_domain: @lti_items_service_domain
+      })
     end
 
     test "returns the url from line items claim when no registration present" do
       assert AGS.get_line_items_url(@lti_params) ==
-        "https://lms.example.edu/api/lti/courses/8/line_items"
+        @line_items_url
+    end
+
+    test "returns the url from line items claim when registration present but not line_items_service_domain" do
+      assert AGS.get_line_items_url(@lti_params, %{auth_server: "some auth_server"}) ==
+        @line_items_url
+
+      assert AGS.get_line_items_url(@lti_params, %{
+        line_items_service_domain: ""
+      }) == @line_items_url
+
+      assert AGS.get_line_items_url(@lti_params, %{
+        line_items_service_domain: nil
+      }) == @line_items_url
     end
 
     test "returns the url from line items claim with the registration auth server domain" do
       assert AGS.get_line_items_url(@lti_params, %{
-        auth_server: "https://registration.example.com/lti/something"
+        line_items_service_domain: @lti_items_service_domain
       }) == "https://registration.example.com/api/lti/courses/8/line_items"
     end
   end


### PR DESCRIPTION
We can't use the `auth_server` as domain for building the line items service url when the registration is present because that field is used for other purposes.

This change replace that to use a new field called `line_items_service_domain` that will be added in the registration. 

Change is backward compatible because if field is not present or is nil, it just use the domain from the claims.