### PR TITLE
[MER-1359] Fix aud claim accepted format and encoding issues

### DIFF
--- a/lib/lti_1p3/tool/launch_validation.ex
+++ b/lib/lti_1p3/tool/launch_validation.ex
@@ -82,9 +82,12 @@ defmodule Lti_1p3.Tool.LaunchValidation do
   defp peek_issuer_client_id(params) do
     with {:ok, jwt_string} <- extract_param(params, "id_token"),
          {:ok, jwt_claims} <- peek_claims(jwt_string) do
-      {:ok, jwt_claims["iss"], jwt_claims["aud"]}
+      {:ok, jwt_claims["iss"], peek_client_id(jwt_claims["aud"])}
     end
   end
+
+  defp peek_client_id([client_id | _]), do: client_id
+  defp peek_client_id(client_id), do: client_id
 
   defp validate_deployment(registration, jwt_body) do
     deployment_id = jwt_body["https://purl.imsglobal.org/spec/lti/claim/deployment_id"]

--- a/lib/lti_1p3/utils.ex
+++ b/lib/lti_1p3/utils.ex
@@ -165,11 +165,10 @@ defmodule Lti_1p3.Utils do
         into: %{},
         do: {
           k,
-          String.replace(v, ["+", "/"], fn
-            "+" -> "-"
-            "/" -> "_"
-            c -> c
-          end)
+          case Base.decode64(v, padding: false) do
+            :error -> v
+            {:ok, decoded} -> Base.url_encode64(decoded, padding: false)
+          end
         }
   end
 end

--- a/lib/lti_1p3/utils.ex
+++ b/lib/lti_1p3/utils.ex
@@ -149,9 +149,27 @@ defmodule Lti_1p3.Utils do
       public_key_json ->
         public_key =
           public_key_json
+          |> convert_to_base64url()
           |> JOSE.JWK.from()
 
         {:ok, public_key}
     end
+  end
+
+  @doc """
+  Given a map representing a JWK, encodes all its values to Base64URL.
+  """
+  @spec convert_to_base64url(map()) :: map()
+  def convert_to_base64url(key_map) do
+    for {k, v} <- key_map,
+        into: %{},
+        do: {
+          k,
+          String.replace(v, ["+", "/"], fn
+            "+" -> "-"
+            "/" -> "_"
+            c -> c
+          end)
+        }
   end
 end

--- a/test/lti_1p3/tool/launch_validation_test.exs
+++ b/test/lti_1p3/tool/launch_validation_test.exs
@@ -10,7 +10,7 @@ defmodule Lti_1p3.Tool.LaunchValidationTest do
   setup :verify_on_exit!
 
   describe "launch validation" do
-    test "passes validation for a valid launch request and caches lti params" do
+    setup do
       jwk = jwk_fixture()
       registration = registration_fixture(%{tool_jwk_id: jwk.id})
       deployment_id = "1"
@@ -19,8 +19,15 @@ defmodule Lti_1p3.Tool.LaunchValidationTest do
         deployment_fixture(%{deployment_id: deployment_id, registration_id: registration.id})
 
       state = "some-state"
-      session_state = state
 
+      [jwk: jwk, registration: registration, deployment_id: deployment_id, state: state]
+    end
+
+    test "passes validation for a valid launch request and caches lti params", %{
+      jwk: jwk,
+      deployment_id: deployment_id,
+      state: state
+    } do
       claims =
         all_default_claims()
         |> put_in(["https://purl.imsglobal.org/spec/lti/claim/deployment_id"], deployment_id)
@@ -31,20 +38,14 @@ defmodule Lti_1p3.Tool.LaunchValidationTest do
       MockHTTPoison
       |> expect(:get, fn _url -> mock_get_jwk_keys(jwk) end)
 
-      assert {:ok, _lti_params} = LaunchValidation.validate(params, session_state)
+      assert {:ok, _lti_params} = LaunchValidation.validate(params, state)
     end
 
-    test "passes validation when aud claim is a list" do
-      jwk = jwk_fixture()
-      registration = registration_fixture(%{tool_jwk_id: jwk.id})
-      deployment_id = "1"
-
-      _deployment =
-        deployment_fixture(%{deployment_id: deployment_id, registration_id: registration.id})
-
-      state = "some-state"
-      session_state = state
-
+    test "passes validation when aud claim is a list", %{
+      jwk: jwk,
+      deployment_id: deployment_id,
+      state: state
+    } do
       claims =
         all_default_claims()
         |> put_in(["https://purl.imsglobal.org/spec/lti/claim/deployment_id"], deployment_id)
@@ -56,20 +57,14 @@ defmodule Lti_1p3.Tool.LaunchValidationTest do
       MockHTTPoison
       |> expect(:get, fn _url -> mock_get_jwk_keys(jwk) end)
 
-      assert {:ok, _lti_params} = LaunchValidation.validate(params, session_state)
+      assert {:ok, _lti_params} = LaunchValidation.validate(params, state)
     end
 
-    test "passes validation when JWK is not Base64URL encoded" do
-      jwk = jwk_fixture()
-      registration = registration_fixture(%{tool_jwk_id: jwk.id})
-      deployment_id = "1"
-
-      _deployment =
-        deployment_fixture(%{deployment_id: deployment_id, registration_id: registration.id})
-
-      state = "some-state"
-      session_state = state
-
+    test "passes validation when JWK is not Base64URL encoded", %{
+      jwk: jwk,
+      deployment_id: deployment_id,
+      state: state
+    } do
       claims =
         all_default_claims()
         |> put_in(["https://purl.imsglobal.org/spec/lti/claim/deployment_id"], deployment_id)
@@ -82,7 +77,7 @@ defmodule Lti_1p3.Tool.LaunchValidationTest do
       MockHTTPoison
       |> expect(:get, fn _url -> mock_get_jwk_keys(jwk, transform: transform_fn) end)
 
-      assert {:ok, _lti_params} = LaunchValidation.validate(params, session_state)
+      assert {:ok, _lti_params} = LaunchValidation.validate(params, state)
     end
   end
 

--- a/test/lti_1p3/utils_test.exs
+++ b/test/lti_1p3/utils_test.exs
@@ -1,0 +1,21 @@
+defmodule Lti_1p3.UtilsTest do
+  use Lti_1p3.Test.TestCase
+
+  alias Lti_1p3.Utils
+
+  describe "convert_to_base64url/1" do
+    test "converts map to Base64URL encoding" do
+      map = %{key: "KXHe3Ef6aEoTnkZpXkuA/++lTQ98"}
+      expected_value = "KXHe3Ef6aEoTnkZpXkuA_--lTQ98"
+
+      assert %{key: ^expected_value} = Utils.convert_to_base64url(map)
+    end
+
+    test "is idempotent when map is already Base64URL encoded" do
+      base64url_encoded_value = "KXHe3Ef6aEoTnkZpXkuA_--lTQ98"
+      map = %{key: base64url_encoded_value}
+
+      assert map == Utils.convert_to_base64url(map)
+    end
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -194,7 +194,7 @@ defmodule Lti_1p3.Test.TestHelpers do
     }
   end
 
-  def mock_get_jwk_keys(jwk) do
+  def mock_get_jwk_keys(jwk, opts \\ []) do
     body =
       Jason.encode!(%{
         keys: [
@@ -207,9 +207,13 @@ defmodule Lti_1p3.Test.TestHelpers do
           |> Map.put("alg", jwk.alg)
           |> Map.put("kid", jwk.kid)
           |> Map.put("use", "sig")
+          |> maybe_transform(opts)
         ]
       })
 
     {:ok, %HTTPoison.Response{status_code: 200, body: body}}
   end
+
+  defp maybe_transform(map, transform: transform_fn), do: transform_fn.(map)
+  defp maybe_transform(map, _opts), do: map
 end


### PR DESCRIPTION
[MER-1359](https://eliterate.atlassian.net/browse/MER-1359)

This PR fixes two existing issues with the library:

1. As the LTI 1.3 protocol states, when [Torus](https://github.com/Simon-Initiative/oli-torus) is launched from an LMS with an `id token` as a parameter, the `aud` field in the token can be either an array of strings or a string ([it is highly recommended to be a one-element-array](https://www.imsglobal.org/spec/security/v1p1#id-token)). Torus uses the `lti_1p3` library that only support string `aud`s, and some LMSs like Schoology are sending arrays as `aud` claim. 

2. Even though all LMSs should expose the JWKS with all its values Base64URL encoded, some of them are just using Base64 ([open bug report in Schoology](https://support.schoology.com/hc/en-us/community/posts/6329539698327-Bug-Report-LTI-1-3-JWKS-should-be-base64url-encoded)). This is causing newer versions of [JOSE](https://github.com/potatosalad/erlang-jose) to fail since the library is expecting Base64URL encoded values ([similar issue here](https://github.com/ritou/elixir-web_authn_lite/issues/9)).