### PR TITLE
[BUGFIX] Ignore non-binary values when converting JWKs to Base64URL

### DIFF
--- a/lib/lti_1p3/utils.ex
+++ b/lib/lti_1p3/utils.ex
@@ -149,7 +149,7 @@ defmodule Lti_1p3.Utils do
       public_key_json ->
         public_key =
           public_key_json
-          |> convert_to_base64url()
+          |> convert_map_to_base64url()
           |> JOSE.JWK.from()
 
         {:ok, public_key}
@@ -159,16 +159,19 @@ defmodule Lti_1p3.Utils do
   @doc """
   Given a map representing a JWK, encodes all its values to Base64URL.
   """
-  @spec convert_to_base64url(map()) :: map()
-  def convert_to_base64url(key_map) do
+  @spec convert_map_to_base64url(map()) :: map()
+  def convert_map_to_base64url(key_map) do
     for {k, v} <- key_map,
         into: %{},
-        do: {
-          k,
-          case Base.decode64(v, padding: false) do
-            :error -> v
-            {:ok, decoded} -> Base.url_encode64(decoded, padding: false)
-          end
-        }
+        do: {k, to_base64url(v)}
   end
+
+  defp to_base64url(value) when is_binary(value) do
+    case Base.decode64(value, padding: false) do
+      :error -> value
+      {:ok, decoded} -> Base.url_encode64(decoded, padding: false)
+    end
+  end
+
+  defp to_base64url(value), do: value
 end

--- a/test/lti_1p3/tool/launch_validation_test.exs
+++ b/test/lti_1p3/tool/launch_validation_test.exs
@@ -72,7 +72,9 @@ defmodule Lti_1p3.Tool.LaunchValidationTest do
       id_token = generate_id_token(jwk, jwk.kid, claims)
       params = %{"state" => state, "id_token" => id_token}
 
-      transform_fn = fn map -> Map.update!(map, "n", &convert_to_base64_encoding(&1)) end
+      transform_fn = fn map ->
+        Map.update!(map, "n", &convert_to_base64_encoding(&1)) |> Map.put("exp", 12345)
+      end
 
       MockHTTPoison
       |> expect(:get, fn _url -> mock_get_jwk_keys(jwk, transform: transform_fn) end)

--- a/test/lti_1p3/utils_test.exs
+++ b/test/lti_1p3/utils_test.exs
@@ -3,19 +3,25 @@ defmodule Lti_1p3.UtilsTest do
 
   alias Lti_1p3.Utils
 
-  describe "convert_to_base64url/1" do
+  describe "convert_map_to_base64url/1" do
     test "converts map to Base64URL encoding" do
       map = %{key: "KXHe3Ef6aEoTnkZpXkuA/++lTQ98"}
       expected_value = "KXHe3Ef6aEoTnkZpXkuA_--lTQ98"
 
-      assert %{key: ^expected_value} = Utils.convert_to_base64url(map)
+      assert %{key: ^expected_value} = Utils.convert_map_to_base64url(map)
     end
 
     test "is idempotent when map is already Base64URL encoded" do
       base64url_encoded_value = "KXHe3Ef6aEoTnkZpXkuA_--lTQ98"
       map = %{key: base64url_encoded_value}
 
-      assert map == Utils.convert_to_base64url(map)
+      assert map == Utils.convert_map_to_base64url(map)
+    end
+
+    test "ignores non-binary values" do
+      map = %{key1: 123, key2: []}
+
+      assert map == Utils.convert_map_to_base64url(map)
     end
   end
 end


### PR DESCRIPTION
Depending on the case, the JWKs exposed by an LMS might include fields like `exp` which have non-binary values. This causes the `Base` library to raise an exception when called with the wrong param type.