### PR TITLE
[FEATURE] [MER-879] Grade sync schoology

### DIFF
--- a/lib/lti_1p3/tool/services/ags/line_item.ex
+++ b/lib/lti_1p3/tool/services/ags/line_item.ex
@@ -1,5 +1,5 @@
 defmodule Lti_1p3.Tool.Services.AGS.LineItem do
-  @derive Jason.Encoder
+  @derive {Jason.Encoder, except: [:id]}
   @enforce_keys [:scoreMaximum, :label, :resourceId]
   defstruct [:id, :scoreMaximum, :label, :resourceId]
 

--- a/lib/lti_1p3/tool/services/nrps.ex
+++ b/lib/lti_1p3/tool/services/nrps.ex
@@ -76,7 +76,8 @@ defmodule Lti_1p3.Tool.Services.NRPS do
   defp headers(%AccessToken{} = access_token) do
     [
       {"Content-Type", "application/json"},
-      {"Authorization", "Bearer #{access_token.access_token}"}
+      {"Authorization", "Bearer #{access_token.access_token}"},
+      {"Accept", "application/vnd.ims.lti-nrps.v2.membershipcontainer+json"}
     ]
   end
 end

--- a/test/lti_1p3/tool/services/ags_test.exs
+++ b/test/lti_1p3/tool/services/ags_test.exs
@@ -412,7 +412,7 @@ defmodule Lti_1p3.Tool.Services.AGSTest do
         )
     end
 
-    test "fetch line item set headers correctly", %{
+    test "fetch line item is build correctly with query params", %{
       access_token: access_token
     } do
       expect(MockHTTPoison, :get, fn url, _headers ->


### PR DESCRIPTION
[MER-879](https://eliterate.atlassian.net/browse/MER-879)

Fixing some issues Schoology was having for syncing grades:
- Do not derive id when is not present in the line item
  - Fixed error: `[error] Error encountered creating line item for 25205 New Assessment 1: {:ok, %HTTPoison.Response{body: "{\"error\":\"Invalid parameter \\\"body.id\\\": \\\"id\\\" is not allowed\"}", headers: [{....`
- Add missing header for fetching memberships:
  - `[error] Error encountered fetching memberships from https://lti-service.svc.schoology.com/lti-service/tool/6055863026/services/names-roles/v2p0/membership/6285150953?limit=1000 {:ok, %HTTPoison.Response{body: "{\"error\":\"handleNamesRoles: Invalid Accept Header\"}", headers: [{...`

Tested that Moodle and Canvas continue working as expected.

Leaving it as draft for now, since it's not fully working yet due to an error from the Schoology side. See ticket in Jira for further information. Although I agree if we want to proceed with these changes anyway.